### PR TITLE
Task/apd 33 fix swagger retrieval

### DIFF
--- a/provider-directory/src/main/java/gov/va/api/health/providerdirectory/service/controller/ProviderDirectoryHomeController.java
+++ b/provider-directory/src/main/java/gov/va/api/health/providerdirectory/service/controller/ProviderDirectoryHomeController.java
@@ -4,10 +4,8 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.io.Resource;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,18 +17,11 @@ public class ProviderDirectoryHomeController {
 
   private static final YAMLMapper MAPPER = new YAMLMapper();
 
-  private final Resource openapi;
-
-  @Autowired
-  public ProviderDirectoryHomeController(@Value("classpath:/openapi.yaml") Resource openapi) {
-    this.openapi = openapi;
-  }
-
   /** The OpenAPI specific content in yaml form. */
   @SuppressWarnings("WeakerAccess")
   @Bean
   public String openapiContent() throws IOException {
-    try (InputStream is = openapi.getInputStream()) {
+    try (InputStream is = new ClassPathResource("openapi.yaml").getInputStream()) {
       return StreamUtils.copyToString(is, Charset.defaultCharset());
     }
   }
@@ -45,7 +36,7 @@ public class ProviderDirectoryHomeController {
   )
   @ResponseBody
   public Object openapiJson() throws IOException {
-    return ProviderDirectoryHomeController.MAPPER.readValue(openapiContent(), Object.class);
+    return MAPPER.readValue(openapiContent(), Object.class);
   }
 
   /** Provide access to the OpenAPI yaml via RESTful interface. */

--- a/provider-directory/src/main/resources/application.properties
+++ b/provider-directory/src/main/resources/application.properties
@@ -1,9 +1,8 @@
 ppms.url=unset
-security.require-ssl=true
-server.ssl.key-store-type=JKS
-server.ssl.key-store=unset
-server.ssl.key-store-password=unset
-server.ssl.key-alias=unset
+server.ssl.client-auth=none
+ssl.use-trust-store=false
+server.ssl.enabled=false
+ssl.enable-client=false
 
 provider-directory.url=unset
 provider-directory.base-path=api

--- a/src/scripts/make-configs.sh
+++ b/src/scripts/make-configs.sh
@@ -57,24 +57,7 @@ makeConfig() {
   local target="$REPO/$project/config/application-${profile}.properties"
   [ -f "$target" ] && mv -v $target $target.$MARKER
   grep -E '(.*= *unset)' "$REPO/$project/src/main/resources/application.properties" \
-    | grep -Ev '(^server\.ssl\.|^ssl\.)' \
     > "$target"
-cat >> "$target" <<EOF
-# Server SSL
-server.ssl.key-store=file:target/certs/system/DVP-DVP-NONPROD.jks
-server.ssl.key-alias=internal-sys-dev
-server.ssl.key-store-password=$KEYSTORE_PASSWORD
-server.ssl.trust-store=file:target/certs/system/DVP-NONPROD-truststore.jks
-server.ssl.trust-store-password=$KEYSTORE_PASSWORD
-server.ssl.client-auth=want
-# Client SSL
-ssl.key-store=file:target/certs/system/DVP-DVP-NONPROD.jks
-ssl.key-store-password=$KEYSTORE_PASSWORD
-ssl.client-key-password=$KEYSTORE_PASSWORD
-ssl.use-trust-store=true
-ssl.trust-store=file:target/certs/system/DVP-NONPROD-truststore.jks
-ssl.trust-store-password=$KEYSTORE_PASSWORD
-EOF
 }
 
 configValue() {
@@ -114,10 +97,10 @@ makeConfig provider-directory $PROFILE
 
 configValue provider-directory $PROFILE capability.contact.name "$(whoDis)"
 configValue provider-directory $PROFILE capability.contact.email "$(sendMoarSpams)"
-configValue provider-directory $PROFILE capability.security.token-endpoint https://fake.com/token
-configValue provider-directory $PROFILE capability.security.authorize-endpoint https://fake.com/authorize
+configValue provider-directory $PROFILE capability.security.token-endpoint http://fake.com/token
+configValue provider-directory $PROFILE capability.security.authorize-endpoint http://fake.com/authorize
 configValue provider-directory $PROFILE ppms.url "$PPMS_URL"
-configValue provider-directory $PROFILE provider-directory.url https://localhost:8080
+configValue provider-directory $PROFILE provider-directory.url http://localhost:8080
 configValue provider-directory $PROFILE well-known.capabilities "context-standalone-patient, launch-ehr, permission-offline, permission-patient"
 configValue provider-directory $PROFILE well-known.response-type-supported "code, refresh_token"
 configValue provider-directory $PROFILE well-known.scopes-supported "patient/DiagnosticReport.read, patient/Patient.read, offline_access"

--- a/src/scripts/make-configs.sh
+++ b/src/scripts/make-configs.sh
@@ -97,8 +97,8 @@ makeConfig provider-directory $PROFILE
 
 configValue provider-directory $PROFILE capability.contact.name "$(whoDis)"
 configValue provider-directory $PROFILE capability.contact.email "$(sendMoarSpams)"
-configValue provider-directory $PROFILE capability.security.token-endpoint http://fake.com/token
-configValue provider-directory $PROFILE capability.security.authorize-endpoint http://fake.com/authorize
+configValue provider-directory $PROFILE capability.security.token-endpoint https://fake.com/token
+configValue provider-directory $PROFILE capability.security.authorize-endpoint https://fake.com/authorize
 configValue provider-directory $PROFILE ppms.url "$PPMS_URL"
 configValue provider-directory $PROFILE provider-directory.url http://localhost:8080
 configValue provider-directory $PROFILE well-known.capabilities "context-standalone-patient, launch-ehr, permission-offline, permission-patient"


### PR DESCRIPTION
https://vasdvp.atlassian.net/browse/APD-33

Fixes in relation to upgrades.
In order for PPMS calls to work, a cert will need to be configured.
Refer to the [SSL notes here](https://github.freedomstream.io/bullseye/bridg_pathways_java) at the bottom of the page and retrieve the cert in Step 1. from PPMS instead of Pathways.  The _.crt_ file change can stay as the downloaded _.cer_.